### PR TITLE
add prop-types dependency for later

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "body-parser": "^1.17.1",
     "eslint-plugin-react": "^6.10.3",
     "express": "^4.15.2",
+    "prop-types": "^15.5.6",
     "react": "^15.5.3",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.3",


### PR DESCRIPTION
Prop-types is now required by react to remove a warning "Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."
Though we don't have any prop types currently, our libs (specifically react-router-dom) do! 
Even though react-router-dom fixed this bug in their github lib yesterday, reinstalling the module (even with --update-binary) doesn't. Neither does removing the bundle cache from jest.
So we just have to wait for the react-router (or some other) npm to catch up with github to get rid of the warning.