### PR TITLE
Feat/workspace editor Fix editor height, add tests and SublimeText keybindings

### DIFF
--- a/client/components/room/Workspace.jsx
+++ b/client/components/room/Workspace.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import CodeMirror from 'react-codemirror';
 
-require('codemirror/lib/codemirror.css');
+// require('codemirror/lib/codemirror.css');
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/markdown/markdown');
@@ -20,9 +20,6 @@ class Workspace extends React.Component {
 
   componentDidMount() {
     const cm = this.refs.cm.getCodeMirror();
-    console.log('cm', cm);
-    console.log('get doc', cm.getDoc());
-    console.log('cm.getValue()', cm.getValue());
     cm.setSize(null, 550);
   }
 

--- a/client/components/room/Workspace.jsx
+++ b/client/components/room/Workspace.jsx
@@ -7,14 +7,23 @@ require('codemirror/mode/xml/xml');
 require('codemirror/mode/markdown/markdown');
 require('codemirror/mode/python/python');
 require('codemirror/mode/ruby/ruby');
+require('codemirror/keymap/sublime');
 
 class Workspace extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      code: '// Ribbit'
+      code: '// Ribbit\nfunction ribbit() {\n return "Ribbit";\n}\n'
     };
     this.updateCode = this.updateCode.bind(this);
+  }
+
+  componentDidMount() {
+    const cm = this.refs.cm.getCodeMirror();
+    console.log('cm', cm);
+    console.log('get doc', cm.getDoc());
+    console.log('cm.getValue()', cm.getValue());
+    cm.setSize(null, 550);
   }
 
   updateCode(newCode) {
@@ -26,11 +35,14 @@ class Workspace extends React.Component {
   render() {
     const options = {
       lineNumbers: true,
+      lineWrapping: true,
+      keyMap: 'sublime',
       mode: 'javascript'
     };
     return (
       <div className="row border left-side">
         <CodeMirror
+          ref="cm"
           value={this.state.code}
           onChange={this.updateCode}
           options={options}

--- a/spec/client-spec/Video.test.jsx
+++ b/spec/client-spec/Video.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import Video from '../../client/components/room/Video';
 
-test('Chat component snapshot test', () => {
+test('Video component snapshot test', () => {
   const component = renderer.create(<Video />);
   const tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/spec/client-spec/Workspace.test.jsx
+++ b/spec/client-spec/Workspace.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
+import Workspace from '../../client/components/room/Workspace';
+
+describe('Workspace should exist and render', () => {
+  test('Workspace component should be a stateful class component', () => {
+    expect(React.Component.isPrototypeOf(Workspace)).toEqual(true);
+  });
+
+  test('Workspace should have a component named CodeMirror', () => {
+    const cmName = shallow(<Workspace/>).node.props.children[0].type.displayName;
+    expect(cmName).toEqual('CodeMirror');
+  });
+
+  test('Workspace should have an initial value', () => {
+    const cmValue = shallow(<Workspace/>).node.props.children[0].props.value;
+    expect(cmValue).toEqual('// Ribbit\nfunction ribbit() {\n return "Ribbit";\n}\n');
+  });
+
+});

--- a/spec/client-spec/__snapshots__/Chat.test.jsx.snap
+++ b/spec/client-spec/__snapshots__/Chat.test.jsx.snap
@@ -5,35 +5,43 @@ exports[`Chat component snapshot test 1`] = `
   className="row border right-side"
 >
   <div
-    className="chat-header"
+    className="container-fluid chat-container"
   >
-    <span
-      className="glyphicon glyphicon-user"
-    />
-    <span>
-      Chat with USER
-    </span>
-  </div>
-  <div
-    className="chat-area"
-  >
-    chat area
-  </div>
-  <div
-    className="chat-input"
-  >
-    <form>
-      <input
-        className="col-md-10 col-sm-10 col-xs-10"
-        placeholder="Type your message here."
-        type="text"
+    <div
+      className="chat-header"
+    >
+      <span
+        className="glyphicon glyphicon-user"
       />
-      <button
-        className="btn-info col-md-2  col-sm-2 col-xs-2"
+      <span
+        className="name-msg-offset"
       >
-        Send
-      </button>
-    </form>
+        Chat with USER
+      </span>
+    </div>
+    <div
+      className="chat-area"
+    />
+    <div
+      className="chat-input"
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <input
+          className="col-md-10 col-sm-10 col-xs-10"
+          onChange={[Function]}
+          placeholder="Type your message here."
+          type="text"
+          value=""
+        />
+        <button
+          className="btn-info col-md-2  col-sm-2 col-xs-2"
+        >
+          Send
+        </button>
+      </form>
+    </div>
   </div>
 </div>
 `;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 require('webpack');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+// const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 
 const BUILD_DIR = path.resolve(__dirname, 'client/public');
@@ -21,28 +21,32 @@ const config = {
           path.join(__dirname, 'node_modules/react-codemirror')
         ],
         loader: 'babel-loader'
-      },
-      {
-        test: /(\.scss|\.css)$/,
-        loader: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: 'css-loader'
-        })
       }
+      // ,
+      // {
+      //   test: /(\.scss|\.css)$/,
+      //   rules: [
+      //     {
+      //       test: /\.css$/,
+      //       use: ['style-loader', 'css-loader']
+      //     }
+      //   ]
+      // }
     ]
   },
   resolve: {
-    extensions: ['.js', '.jsx', '.json', '.scss', '.css'],
+    extensions: ['.js', '.jsx'],
     moduleExtensions: [
       'node_modules',
       path.resolve(__dirname, 'src/scripts'),
       path.resolve(__dirname, 'src')
     ]
-  },
-  plugins: [
-    new ExtractTextPlugin('styles.css')
-    // this may be pointing at the wrong file endpoint
-  ]
+  }
+  // ,
+  // plugins: [
+  //   new ExtractTextPlugin('styles.css')
+  //   // this may be pointing at the wrong file endpoint
+  // ]
 };
 
 module.exports = config;


### PR DESCRIPTION
Text Editor now takes up a reasonable amount of space.
Text Editor also uses the SublimeText Shortcut keys, such as (Cmd+D) to select a word/ multiple instances of a word or (Cmd+Shift+D) to duplicate a line!
Removed offending Webpack code creating superfluous styles.css file.

Added Workspace tests.
Updated Chat snapshot test to pass.
Fixed spelling mistake in Video test.
Video snapshot test is still broken: "TypeError: Cannot read property 'getUserMedia' of undefined"
https://trello.com/c/PUyYi0dX