### PR TITLE
Add P2P code editing with socket.io

### DIFF
--- a/client/components/room/Workspace.jsx
+++ b/client/components/room/Workspace.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CodeMirror from 'react-codemirror';
+import io from 'socket.io-client';
 
 // require('codemirror/lib/codemirror.css');
 require('codemirror/mode/javascript/javascript');
@@ -9,23 +10,43 @@ require('codemirror/mode/python/python');
 require('codemirror/mode/ruby/ruby');
 require('codemirror/keymap/sublime');
 
+const server = location.origin;
+const socket = io(server);
+let cm;
+
 class Workspace extends React.Component {
   constructor(props) {
     super(props);
+    // mock user value for now
     this.state = {
+      user: Math.floor(999 * Math.random()),
       code: '// Ribbit\nfunction ribbit() {\n return "Ribbit";\n}\n'
     };
-    this.updateCode = this.updateCode.bind(this);
+    this.updateCodeHandler = this.updateCodeHandler.bind(this);
   }
 
   componentDidMount() {
-    const cm = this.refs.cm.getCodeMirror();
+    cm = this.refs.cm.getCodeMirror();
+
+    cm.on('keyup', () => {
+      const editedCode = {
+        id: 1,
+        user: this.state.user,
+        value: cm.getValue()
+      };
+      this.setState({
+        code: editedCode.value
+      });
+      socket.emit('code-edit', editedCode);
+    });
+    socket.on('newCode', this.updateCodeHandler);
     cm.setSize(null, 550);
   }
 
-  updateCode(newCode) {
+  updateCodeHandler(otherPersonsCode) {
+    cm.setValue(otherPersonsCode.value);
     this.setState({
-      code: newCode
+      code: otherPersonsCode.value
     });
   }
 
@@ -41,7 +62,6 @@ class Workspace extends React.Component {
         <CodeMirror
           ref="cm"
           value={this.state.code}
-          onChange={this.updateCode}
           options={options}
         />
         This is the Workspace Component

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,9 @@ io.on('connection', (socket) => {
   socket.on('disconnect', () => {
     // console.log('user disconnected');
   });
+  socket.on('code-edit', (code) => {
+    socket.broadcast.emit('newCode', code);
+  });
 });
 
 http.listen(port, () => {


### PR DESCRIPTION
The code one user types into a code editor will update the code on another user's code editor.
The variable cm is floating outside the class. This is because CodeMirror cannot be called until it has mounted, but is also useful in the eventhandler.
The other option is to call 
`cm = this.refs.cm.getCodeMirror();`
every time we want to edit the state (any keyboard press!). Simply editing the state causes error and doesn't allow for deletion of characters.

https://trello.com/c/br4Qp1Fo