### PR TITLE
fix jumping cursor bug and codeExec array/obj parsing bug

### DIFF
--- a/client/components/room/Workspace.jsx
+++ b/client/components/room/Workspace.jsx
@@ -32,15 +32,11 @@ class Workspace extends React.Component {
 
     cm.on('keyup', () => {
       const editedCode = {
-        id: 1,
         user: this.state.user,
         value: cm.getValue(),
         language: 'Javascript',
         room: this.props.roomName
       };
-      this.setState({
-        code: editedCode.value
-      });
       socket.emit('code-edit', editedCode);
     });
     socket.on('newCode', this.updateCodeHandler);
@@ -55,14 +51,19 @@ class Workspace extends React.Component {
   }
 
   runCodeButtonListener() {
+    this.setState({
+      code: cm.getValue()
+    });
+
     axios.get('/runCode', {
       params: {
-        value: this.state.code,
+        value: cm.getValue(),
         language: 'Javascript'
       }
     })
     .then((response) => {
       console.log(response.request.responseText);
+      console.log(JSON.parse(response.request.responseText));
       this.setState({
         result: `Docker-Container: Ribbit user$ ${response.request.responseText}`
       });

--- a/server/index.js
+++ b/server/index.js
@@ -39,7 +39,7 @@ app.get('/', (req, res) => {
 app.get('/runCode', (req, res) => {
   const result = codeParser(req.query);
   console.log(result);
-  res.status(200).send(result.toString());
+  res.status(200).send(JSON.stringify(result));
 });
 
 app.get('*', (req, res) => {


### PR DESCRIPTION
Users can now type fast without the cursor jumping to the beginning of the code editor. State was being set too aggressively and conflicting with codemirror's internal state management.

https://trello.com/c/KDJf0QUg

Users can now receive code results with objects and arrays included. Forgot to JSON.stringify results over just results.toString().

https://trello.com/c/7VWAdX0A

Also removed id, which was a stand-in for roomname.