### PR TITLE
(bug) fixed fb_runCode bug by removing unnecessary fbAuth on route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ app.get('/', (req, res) => {
   res.status(200).send();
 });
 
-app.get('/runCode', passport.authenticate('facebook'), (req, res) => {
+app.get('/runCode', (req, res) => {
   const result = codeParser(req.query);
   console.log(result);
   res.status(200).send(JSON.stringify(result));

--- a/server/initPassport.js
+++ b/server/initPassport.js
@@ -3,7 +3,7 @@ const FacebookStrategy = require('passport-facebook').Strategy;
 require('dotenv').config();
 
 passport.use(new FacebookStrategy({
-    clientID: '1871157256463548' || process.env.FB_APPID,
+    clientID: process.env.FB_APPID || '1871157256463548',
     clientSecret: process.env.FB_APPSECRET,
     callbackURL: 'http://www.google.com'
 },


### PR DESCRIPTION
Fixed  bug where " '/runCode' route was being denied from running" by removing unnecessary fbAuth on route.
Also, fixed the positioning of process.env.FB_APPID with it's default, so the env variable will be used when available.

