### PR TITLE
(Bug) Urls in browser will now render the room they reference

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -32,7 +32,7 @@ class App extends React.Component {
           <Route exact path="/" component={Home} />
           <Route exact path="/login" component={Login} />
           <Route exact path="/profile" component={Profile} />
-          <Route path={`/:${this.props.roomName}`} history={this.props.history} component={Room} />
+          <Route path={`/:roomName`} history={props.history} component={Room} />
         </Switch>
       </div>
     );

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -32,7 +32,7 @@ class App extends React.Component {
           <Route exact path="/" component={Home} />
           <Route exact path="/login" component={Login} />
           <Route exact path="/profile" component={Profile} />
-          <Route path={`/:roomName`} history={props.history} component={Room} />
+          <Route path={`/:roomName`} history={this.props.history} component={Room} />
         </Switch>
       </div>
     );

--- a/client/components/room/Room.jsx
+++ b/client/components/room/Room.jsx
@@ -6,15 +6,23 @@ import { addUserName, addPeerName, previousRoomNames } from './../../actions/act
 import Video from './Video';
 import Workspace from './Workspace';
 import Chat from './Chat';
+import { addUserName, createRoomName, addPeerName } from './../../actions/actionCreators';
+import RoomDropdown from './RoomDropdown';
 
 
 class Room extends React.Component {
   constructor(props) {
     super(props);
     this.createSillyName = this.createSillyName.bind(this);
+    if (!this.props.roomName) {
+      const browserRoomName = this.props.match.params.roomName.slice(1);
+      this.props.createRoomName(browserRoomName);
+    }
   }
 
   componentDidMount() {
+    const browserRoomNamed = this.props.match.params.roomName.slice(1);
+    socket.emit('join room', this.props.roomName || browserRoomNamed);
     socket.on('peer name', this.props.addPeerName);
     const roomInfo = {
       roomName: this.props.roomName,
@@ -26,6 +34,7 @@ class Room extends React.Component {
       console.log(`${room} is full`);
       this.setState({ redirect: true });
     });
+
     !this.props.userName ? this.createSillyName() : null;
     this.props.previousRoomNames(this.props.roomName);
   }
@@ -64,7 +73,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   addUserName: name => dispatch(addUserName(name)),
   addPeerName: peerName => dispatch(addPeerName(peerName)),
-  previousRoomNames: peerName => dispatch(previousRoomNames(peerName))
+  previousRoomNames: peerName => dispatch(previousRoomNames(peerName)),
+  createRoomName: room => dispatch(createRoomName(room))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Room);

--- a/client/components/room/Room.jsx
+++ b/client/components/room/Room.jsx
@@ -5,7 +5,7 @@ import socket from '../../clientUtilities/sockets';
 import Video from './Video';
 import Workspace from './Workspace';
 import Chat from './Chat';
-import { addUserName, createRoomName, addPeerName } from './../../actions/actionCreators';
+import { addUserName, createRoomName, addPeerName, previousRoomNames } from './../../actions/actionCreators';
 import RoomDropdown from './RoomDropdown';
 
 
@@ -23,12 +23,6 @@ class Room extends React.Component {
     const browserRoomNamed = this.props.match.params.roomName.slice(1);
     socket.emit('join room', this.props.roomName || browserRoomNamed);
     socket.on('peer name', this.props.addPeerName);
-    const roomInfo = {
-      roomName: this.props.roomName,
-      userName: this.props.userName,
-      userId: this.props.userId
-    };
-    socket.emit('join room', roomInfo);
     socket.on('full', (room) => {
       console.log(`${room} is full`);
       this.setState({ redirect: true });

--- a/client/components/room/Room.jsx
+++ b/client/components/room/Room.jsx
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import React from 'react';
 import generateSillyName from 'sillyname';
 import socket from '../../clientUtilities/sockets';
-import { addUserName, addPeerName, previousRoomNames } from './../../actions/actionCreators';
 import Video from './Video';
 import Workspace from './Workspace';
 import Chat from './Chat';

--- a/client/reducers/roomNameReducer.js
+++ b/client/reducers/roomNameReducer.js
@@ -1,4 +1,4 @@
-const roomNameReducer = (state = [], action) => {
+const roomNameReducer = (state = '', action) => {
   if (action.type === 'CREATE_ROOM_NAME') {
     return action.roomName;
   }

--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,25 @@ app.get('/fbcheck',
   }));
 
 app.get('*', (req, res) => {
-  res.status(302).redirect('/');
+  const options = {
+    root: './client/',
+    dotfiles: 'deny',
+    headers: {
+      'x-timestamp': Date.now(),
+      'x-sent': true
+    }
+  };
+
+  const fileName = req.params.name;
+  console.log(fileName);
+  res.sendFile('index.html', options, (err) => {
+    if (err) {
+      console.error(err);
+      // res.status(404).send('404, page not found');
+    } else {
+      console.log('Sent:', fileName);
+    }
+  });
 });
 
 // sockets

--- a/server/sockets/paths.js
+++ b/server/sockets/paths.js
@@ -8,26 +8,26 @@ module.exports = (http) => {
     const namedRooms = utils.namedRooms(io);
     socket.on('join room', (room) => {
     socket.emit('hello', 'emitted hello');
-      const numClients = utils.countClients(namedRooms, room.roomName);
+      const numClients = utils.countClients(namedRooms, room);
       // room = {roomName, userId}
       // max two clients
       if (numClients === 2) {
-        socket.emit('full', room.roomName);
+        socket.emit('full', room);
         return;
       }
-      console.log(`Room ${room.roomName} now has ${numClients + 1} client(s)`);
+      console.log(`Room ${room} now has ${numClients + 1} client(s)`);
       if (numClients === 0) {
-        socket.join(room.roomName);
-        console.log(`Client ID ${socket.id} created room ${room.roomName}`);
-        socket.emit('Created', room.roomName, socket.id);
+        socket.join(room);
+        console.log(`Client ID ${socket.id} created room ${room}`);
+        socket.emit('Created', room, socket.id);
       } else {
-        console.log(`Client ID ${socket.id} joined room ${room.roomName}`);
-        io.sockets.in(room.roomName).emit('Join', room.roomName);
-        socket.join(room.roomName);
-        socket.emit('Joined', room.roomName, socket.id);
-        io.sockets.in(room.roomName).emit('Ready');
+        console.log(`Client ID ${socket.id} joined room ${room}`);
+        io.sockets.in(room).emit('Join', room);
+        socket.join(room);
+        socket.emit('Joined', room, socket.id);
+        io.sockets.in(room).emit('Ready');
       }
-      if (room.userName.length > 0) {
+      if (room.userName && room.userName.length > 0) {
         console.log('username = ', room.userName);
         socket.broadcast.emit('peer name', room.userName);
       }


### PR DESCRIPTION
Originally thought the only way to make outside urls work was to do server-side rendering. So I spent a day going down that rabbit-hole. 
Then I learned that react-router, if correctly passed the url by res.sendFile, will parse it. And the reason we were not rendering the rooms was that our wildcard route was redirecting, which removes the url. 

Now we can go to rooms directly from the without redirecting or rendering the home page, meaning that the createRoute.jsx never put the room into Redux.

This broke the chat, which I then fixed. Assumptions that we would always go through createRoute.jsx or at least Home.jsx may have caused some other bugs that I didn't catch, so look out for those. 